### PR TITLE
Detect missing SerializedName annotation in Retrofit request body

### DIFF
--- a/.github/workflows/buildCheck.yml
+++ b/.github/workflows/buildCheck.yml
@@ -20,3 +20,25 @@ jobs:
 
       - name: Run build
         run: ./gradlew build --stacktrace
+  detekt:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Gradle Files
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - name: Run detektMain
+        run: ./gradlew detektMain
+      - name: Stop Gradle
+        run: ./gradlew --stop

--- a/.github/workflows/buildCheck.yml
+++ b/.github/workflows/buildCheck.yml
@@ -20,25 +20,3 @@ jobs:
 
       - name: Run build
         run: ./gradlew build --stacktrace
-  detekt:
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Cache Gradle Files
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle
-      - name: Setup Java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-      - name: Run detektMain
-        run: ./gradlew detektMain
-      - name: Stop Gradle
-        run: ./gradlew --stop

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,13 @@ tasks.named("dependencyUpdates").configure {
     }
 }
 
+subprojects {
+    apply plugin: 'io.gitlab.arturbosch.detekt'
+    detekt {
+        reports.html.enabled = true
+    }
+}
+
 wrapper {
     gradleVersion = '7.4.2'
     distributionType = Wrapper.DistributionType.BIN

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-    ext.kotlin_version = "1.6.10"
+    ext.kotlin_version = "1.6.21"
+    ext.lint_version = "30.1.3"
 
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.1"
+        classpath "com.android.tools.build:gradle:7.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.gradleup:auto-manifest-plugin:1.0.4'
@@ -49,6 +50,6 @@ tasks.named("dependencyUpdates").configure {
 }
 
 wrapper {
-    gradleVersion = '7.4'
+    gradleVersion = '7.4.2'
     distributionType = Wrapper.DistributionType.BIN
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ buildscript {
 
 plugins {
     id("com.gradleup.auto.manifest") version "1.0.4"
+    id("io.gitlab.arturbosch.detekt") version "1.20.0"
+    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+    id("com.github.ben-manes.versions") version "0.42.0"
 }
 
 allprojects {
@@ -36,6 +39,13 @@ autoManifest {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+tasks.named("dependencyUpdates").configure {
+    checkForGradleUpdate = true
+    rejectVersionIf {
+        ['BETA', 'ALPHA', 'M1', 'RC'].any { word -> it.candidate.version.toUpperCase().contains(word) }
+    }
 }
 
 wrapper {

--- a/checks/build.gradle
+++ b/checks/build.gradle
@@ -18,11 +18,11 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compileOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compileOnly "com.android.tools.lint:lint-api:30.1.1"
-    compileOnly "com.android.tools.lint:lint-checks:30.1.1"
+    compileOnly "com.android.tools.lint:lint-api:$lint_version"
+    compileOnly "com.android.tools.lint:lint-checks:$lint_version"
 
-    testImplementation "com.android.tools.lint:lint:30.1.1"
-    testImplementation "com.android.tools.lint:lint-tests:30.1.1"
+    testImplementation "com.android.tools.lint:lint:$lint_version"
+    testImplementation "com.android.tools.lint:lint-tests:$lint_version"
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }

--- a/checks/src/main/java/com/kozaxinan/android/checks/ImmutableDataClassDetector.kt
+++ b/checks/src/main/java/com/kozaxinan/android/checks/ImmutableDataClassDetector.kt
@@ -1,8 +1,14 @@
 package com.kozaxinan.android.checks
 
 import com.android.tools.lint.client.api.UElementHandler
-import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Detector.UastScanner
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
 import com.intellij.psi.PsiModifier
 import org.jetbrains.kotlin.asJava.elements.KtLightField
 import org.jetbrains.uast.UClass

--- a/checks/src/main/java/com/kozaxinan/android/checks/NetworkLayerClassImmutabilityDetector.kt
+++ b/checks/src/main/java/com/kozaxinan/android/checks/NetworkLayerClassImmutabilityDetector.kt
@@ -23,7 +23,7 @@ internal class NetworkLayerClassImmutabilityDetector : RetrofitReturnTypeDetecto
 
         override fun visitMethod(node: UMethod) {
 
-            val fields = findAllFieldsOf(node)
+            val fields = findAllReturnTypeFieldsOf(node)
 
             val nonFinalFields = fields.filterNot { it.hasModifierProperty(PsiModifier.FINAL) }
             if (nonFinalFields.isNotEmpty()) {

--- a/checks/src/main/java/com/kozaxinan/android/checks/NetworkLayerClassJsonDetector.kt
+++ b/checks/src/main/java/com/kozaxinan/android/checks/NetworkLayerClassJsonDetector.kt
@@ -24,7 +24,8 @@ internal class NetworkLayerClassJsonDetector : RetrofitReturnTypeDetector() {
     class NetworkLayerDtoFieldVisitor(private val context: JavaContext) : Visitor(context) {
 
         override fun visitMethod(node: UMethod) {
-            val allFields: List<UField> = findAllFieldsOf(node).filterNot { !it.isStatic && it.getContainingUClass()?.isEnum == true }
+            val allFields: List<UField> = findAllReturnTypeFieldsOf(node)
+                .filterNot { !it.isStatic && it.getContainingUClass()?.isEnum == true }
 
             val classes: Set<PsiClass> = allFields
                     .mapNotNull { it.getContainingUClass() }

--- a/checks/src/main/java/com/kozaxinan/android/checks/NetworkLayerClassSerializedNameDetector.kt
+++ b/checks/src/main/java/com/kozaxinan/android/checks/NetworkLayerClassSerializedNameDetector.kt
@@ -32,8 +32,7 @@ internal class NetworkLayerClassSerializedNameDetector : RetrofitReturnTypeDetec
                     issue = ISSUE_NETWORK_LAYER_CLASS_SERIALIZED_NAME_RULE,
                     scopeClass = node,
                     location = context.getNameLocation(node),
-                    message = "Return type ${node.returnType} doesn't have @SerializedName annotation for " +
-                        "$nonFinalFields fields."
+                    message = "Return type doesn't have @SerializedName annotation for $nonFinalFields fields."
                 )
             }
 

--- a/checks/src/main/java/com/kozaxinan/android/checks/NetworkLayerClassSerializedNameDetector.kt
+++ b/checks/src/main/java/com/kozaxinan/android/checks/NetworkLayerClassSerializedNameDetector.kt
@@ -12,7 +12,7 @@ import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.getContainingUClass
 
 /**
- * Check retrotif interface methods return type for SerializedName annotation.
+ * Check retrofit interface methods return type for SerializedName annotation.
  */
 @Suppress("UnstableApiUsage")
 internal class NetworkLayerClassSerializedNameDetector : RetrofitReturnTypeDetector() {
@@ -22,40 +22,59 @@ internal class NetworkLayerClassSerializedNameDetector : RetrofitReturnTypeDetec
     class NetworkLayerDtoFieldVisitor(private val context: JavaContext) : Visitor(context) {
 
         override fun visitMethod(node: UMethod) {
-            val nonFinalFields = findAllFieldsOf(node)
-                    .filterNot { !it.isStatic && it.getContainingUClass()?.isEnum == true }
-                    .filterNot(::hasSerializedNameAnnotation)
-                    .map { it.name }
+            val nonFinalFields = findAllReturnTypeFieldsOf(node)
+                .filterNot { !it.isStatic && it.getContainingUClass()?.isEnum == true }
+                .filterNot(::hasSerializedNameAnnotation)
+                .map { it.name }
 
             if (nonFinalFields.isNotEmpty()) {
                 context.report(
-                        issue = ISSUE_NETWORK_LAYER_CLASS_SERIALIZED_NAME_RULE,
-                        scopeClass = node,
-                        location = context.getNameLocation(node),
-                        message = "Return type doesn't have @SerializedName annotation for $nonFinalFields fields."
+                    issue = ISSUE_NETWORK_LAYER_CLASS_SERIALIZED_NAME_RULE,
+                    scopeClass = node,
+                    location = context.getNameLocation(node),
+                    message = "Return type ${node.returnType} doesn't have @SerializedName annotation for " +
+                        "$nonFinalFields fields."
                 )
+            }
+
+            findAllBodyParameterTypeFieldsOf(node)?.let { (classType, fieldsList) ->
+                fieldsList
+                    .filterNot { !it.isStatic && it.getContainingUClass()?.isEnum == true }
+                    .filterNot(::hasSerializedNameAnnotation)
+                    .map { it.name }
+                    .takeIf { it.isNotEmpty() }
+                    ?.let {
+                        context.report(
+                            issue = ISSUE_NETWORK_LAYER_CLASS_SERIALIZED_NAME_RULE,
+                            scopeClass = node,
+                            location = context.getNameLocation(node),
+                            message = "Body type $classType doesn't have @SerializedName annotation for " +
+                                "$it fields."
+                        )
+                    }
             }
         }
 
         private fun hasSerializedNameAnnotation(field: UField): Boolean {
             return context
-                    .evaluator
-                    .getAllAnnotations(field as UAnnotated, true)
-                    .mapNotNull { uAnnotation -> uAnnotation.qualifiedName }
-                    .any { it.endsWith("SerializedName") }
+                .evaluator
+                .getAllAnnotations(field as UAnnotated, true)
+                .mapNotNull { uAnnotation -> uAnnotation.qualifiedName }
+                .any { it.endsWith("SerializedName") }
         }
     }
 
     companion object {
 
         val ISSUE_NETWORK_LAYER_CLASS_SERIALIZED_NAME_RULE: Issue = Issue.create(
-                id = "NetworkLayerClassSerializedNameRule",
-                briefDescription = "SerializedName annotated network layer class",
-                explanation = "Data classes used in network layer should use SerializedName annotation for Gson. Adding annotation prevents obfuscation errors.",
-                category = CORRECTNESS,
-                priority = 5,
-                severity = INFORMATIONAL,
-                implementation = Implementation(NetworkLayerClassSerializedNameDetector::class.java, Scope.JAVA_FILE_SCOPE)
+            id = "NetworkLayerClassSerializedNameRule",
+            briefDescription = "SerializedName annotated network layer class",
+            explanation = "Classes used in network layer should use SerializedName annotation for Gson. " +
+                "Adding annotation prevents obfuscation errors.",
+            category = CORRECTNESS,
+            priority = 5,
+            severity = INFORMATIONAL,
+            implementation = Implementation(NetworkLayerClassSerializedNameDetector::class.java, Scope.JAVA_FILE_SCOPE)
         )
     }
 }

--- a/checks/src/main/java/com/kozaxinan/android/checks/RetrofitReturnTypeDetector.kt
+++ b/checks/src/main/java/com/kozaxinan/android/checks/RetrofitReturnTypeDetector.kt
@@ -35,11 +35,11 @@ import org.jetbrains.uast.toUElement
  * for this example, [Visitor.findAllReturnTypeFieldsOf] will return list of UField for the fields of DTO. {a, b}
  */
 @Suppress("UnstableApiUsage")
-internal abstract class RetrofitReturnTypeDetector : Detector(), UastScanner {
+internal open class RetrofitReturnTypeDetector : Detector(), UastScanner {
 
     override fun getApplicableUastTypes(): List<Class<UMethod>> = listOf(UMethod::class.java)
 
-    abstract class Visitor(private val context: JavaContext) : UElementHandler() {
+    open class Visitor(private val context: JavaContext) : UElementHandler() {
 
         private val listOfRetrofitAnnotations = listOf(
             "retrofit2.http.DELETE",
@@ -76,6 +76,7 @@ internal abstract class RetrofitReturnTypeDetector : Detector(), UastScanner {
             }
         }
 
+        @Suppress("ReturnCount")
         fun findAllBodyParameterTypeFieldsOf(node: UMethod): Pair<PsiClassType, List<UField>>? {
             if (node.getContainingUClass()?.isInterface != true || !hasRetrofitAnnotation(node)) {
                 return null

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -113,9 +113,11 @@ complexity:
   LargeClass:
     active: true
     threshold: 600
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
   LongMethod:
     active: true
     threshold: 60
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
   LongParameterList:
     active: true
     functionThreshold: 6
@@ -575,7 +577,7 @@ style:
   NestedClassesVisibility:
     active: true
   NewLineAtEndOfFile:
-    active: true
+    active: false
   NoTabs:
     active: false
   ObjectLiteralToLambda:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,682 @@
+build:
+  maxIssues: 0
+  excludeCorrectable: false
+  weights:
+    # complexity: 2
+    # LongParameterList: 1
+    # style: 1
+    # comments: 1
+
+config:
+  validation: true
+  warningsAsErrors: false
+  # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+  excludes: ''
+
+processors:
+  active: true
+  exclude:
+    - 'DetektProgressListener'
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
+  # - 'FunctionCountProcessor'
+  # - 'PropertyCountProcessor'
+  # - 'ProjectComplexityProcessor'
+  # - 'ProjectCognitiveComplexityProcessor'
+  # - 'ProjectLLOCProcessor'
+  # - 'ProjectCLOCProcessor'
+  # - 'ProjectLOCProcessor'
+  # - 'ProjectSLOCProcessor'
+  # - 'LicenseHeaderLoaderExtension'
+
+console-reports:
+  active: true
+  exclude:
+     - 'ProjectStatisticsReport'
+     - 'ComplexityReport'
+     - 'NotificationReport'
+     - 'FindingsReport'
+     - 'FileBasedFindingsReport'
+  #  - 'LiteFindingsReport'
+
+output-reports:
+  active: true
+  exclude:
+  # - 'TxtOutputReport'
+  # - 'XmlOutputReport'
+  # - 'HtmlOutputReport'
+
+comments:
+  active: true
+  AbsentOrWrongFileLicense:
+    active: false
+    licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  DeprecatedBlockTag:
+    active: false
+  EndOfSentenceFormat:
+    active: false
+    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
+  OutdatedDocumentation:
+    active: false
+    matchTypeParameters: true
+    matchDeclarationsOrder: true
+    allowParamOnConstructorProperties: false
+  UndocumentedPublicClass:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+  UndocumentedPublicFunction:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+  UndocumentedPublicProperty:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+
+complexity:
+  active: true
+  ComplexCondition:
+    active: true
+    threshold: 4
+  ComplexInterface:
+    active: false
+    threshold: 10
+    includeStaticDeclarations: false
+    includePrivateDeclarations: false
+  ComplexMethod:
+    active: true
+    threshold: 15
+    ignoreSingleWhenExpression: false
+    ignoreSimpleWhenEntries: false
+    ignoreNestingFunctions: false
+    nestingFunctions:
+      - 'also'
+      - 'apply'
+      - 'forEach'
+      - 'isNotNull'
+      - 'ifNull'
+      - 'let'
+      - 'run'
+      - 'use'
+      - 'with'
+  LabeledExpression:
+    active: false
+    ignoredLabels: []
+  LargeClass:
+    active: true
+    threshold: 600
+  LongMethod:
+    active: true
+    threshold: 60
+  LongParameterList:
+    active: true
+    functionThreshold: 6
+    constructorThreshold: 7
+    ignoreDefaultParameters: false
+    ignoreDataClasses: true
+    ignoreAnnotatedParameter: []
+  MethodOverloading:
+    active: false
+    threshold: 6
+  NamedArguments:
+    active: false
+    threshold: 3
+    ignoreArgumentsMatchingNames: false
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  ReplaceSafeCallChainWithRun:
+    active: false
+  StringLiteralDuplication:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    threshold: 3
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+  TooManyFunctions:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    thresholdInFiles: 11
+    thresholdInClasses: 11
+    thresholdInInterfaces: 11
+    thresholdInObjects: 11
+    thresholdInEnums: 11
+    ignoreDeprecated: false
+    ignorePrivate: false
+    ignoreOverridden: false
+
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: false
+  InjectDispatcher:
+    active: false
+    dispatcherNames:
+      - 'IO'
+      - 'Default'
+      - 'Unconfined'
+  RedundantSuspendModifier:
+    active: false
+  SleepInsteadOfDelay:
+    active: false
+  SuspendFunWithCoroutineScopeReceiver:
+    active: false
+  SuspendFunWithFlowReturnType:
+    active: false
+
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: false
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+exceptions:
+  active: true
+  ExceptionRaisedInUnexpectedLocation:
+    active: true
+    methodNames:
+      - 'equals'
+      - 'finalize'
+      - 'hashCode'
+      - 'toString'
+  InstanceOfCheckForException:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+  NotImplementedDeclaration:
+    active: false
+  ObjectExtendsThrowable:
+    active: false
+  PrintStackTrace:
+    active: true
+  RethrowCaughtException:
+    active: true
+  ReturnFromFinally:
+    active: true
+    ignoreLabeled: false
+  SwallowedException:
+    active: true
+    ignoredExceptionTypes:
+      - 'InterruptedException'
+      - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  ThrowingExceptionFromFinally:
+    active: true
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    exceptions:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Exception'
+      - 'IllegalArgumentException'
+      - 'IllegalMonitorStateException'
+      - 'IllegalStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+  ThrowingNewInstanceOfSameException:
+    active: true
+  TooGenericExceptionCaught:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    exceptionNames:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+      - 'Error'
+      - 'Exception'
+      - 'RuntimeException'
+      - 'Throwable'
+
+naming:
+  active: true
+  BooleanPropertyNaming:
+    active: false
+    allowedPattern: '^(is|has|are)'
+    ignoreOverridden: true
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  EnumNaming:
+    active: true
+    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
+  ForbiddenClassName:
+    active: false
+    forbiddenName: []
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+  FunctionNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    functionPattern: '[a-z][a-zA-Z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  FunctionParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  InvalidPackageDeclaration:
+    active: false
+    rootPackage: ''
+    requireRootInDeclaration: false
+  LambdaParameterNaming:
+    active: false
+    parameterPattern: '[a-z][A-Za-z0-9]*|_'
+  MatchingDeclarationName:
+    active: true
+    mustBeFirst: true
+  MemberNameEqualsClassName:
+    active: true
+    ignoreOverridden: true
+  NoNameShadowing:
+    active: false
+  NonBooleanPropertyPrefixedWithIs:
+    active: false
+  ObjectPropertyNaming:
+    active: true
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+
+performance:
+  active: true
+  ArrayPrimitive:
+    active: true
+  ForEachOnRange:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+  SpreadOperator:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  AvoidReferentialEquality:
+    active: false
+    forbiddenTypePatterns:
+      - 'kotlin.String'
+  CastToNullableType:
+    active: false
+  Deprecation:
+    active: false
+  DontDowncastCollectionTypes:
+    active: false
+  DoubleMutabilityForCollection:
+    active: false
+    mutableTypes:
+      - 'kotlin.collections.MutableList'
+      - 'kotlin.collections.MutableMap'
+      - 'kotlin.collections.MutableSet'
+      - 'java.util.ArrayList'
+      - 'java.util.LinkedHashSet'
+      - 'java.util.HashSet'
+      - 'java.util.LinkedHashMap'
+      - 'java.util.HashMap'
+  DuplicateCaseInWhenExpression:
+    active: true
+  ElseCaseInsteadOfExhaustiveWhen:
+    active: false
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExitOutsideMain:
+    active: false
+  ExplicitGarbageCollectionCall:
+    active: true
+  HasPlatformType:
+    active: false
+  IgnoredReturnValue:
+    active: false
+    restrictToAnnotatedMethods: true
+    returnValueAnnotations:
+      - '*.CheckResult'
+      - '*.CheckReturnValue'
+    ignoreReturnValueAnnotations:
+      - '*.CanIgnoreReturnValue'
+    ignoreFunctionCall: []
+  ImplicitDefaultLocale:
+    active: true
+  ImplicitUnitReturnType:
+    active: false
+    allowExplicitReturnType: true
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  LateinitUsage:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    ignoreOnClassesPattern: ''
+  MapGetWithNotNullAssertionOperator:
+    active: false
+  MissingPackageDeclaration:
+    active: false
+    excludes: ['**/*.kts']
+  MissingWhenCase:
+    active: true
+    allowElseExpression: true
+  NullCheckOnMutableProperty:
+    active: false
+  NullableToStringCall:
+    active: false
+  RedundantElseInWhen:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: false
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
+    active: false
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+  UnsafeCast:
+    active: true
+  UnusedUnaryOperator:
+    active: false
+  UselessPostfixExpression:
+    active: false
+  WrongEqualsTypeParameter:
+    active: true
+
+style:
+  active: true
+  CanBeNonNullable:
+    active: false
+  ClassOrdering:
+    active: false
+  CollapsibleIfStatements:
+    active: false
+  DataClassContainsFunctions:
+    active: false
+    conversionFunctionPrefix: 'to'
+  DataClassShouldBeImmutable:
+    active: false
+  DestructuringDeclarationWithTooManyEntries:
+    active: false
+    maxDestructuringEntries: 3
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExplicitItLambdaParameter:
+    active: false
+  ExpressionBodySyntax:
+    active: false
+    includeLineWrapping: false
+  ForbiddenComment:
+    active: true
+    values:
+      - 'FIXME:'
+      - 'STOPSHIP:'
+      - 'TODO:'
+    allowedPatterns: ''
+    customMessage: ''
+  ForbiddenImport:
+    active: false
+    imports: []
+    forbiddenPatterns: ''
+  ForbiddenMethodCall:
+    active: false
+    methods:
+      - 'kotlin.io.print'
+      - 'kotlin.io.println'
+  ForbiddenPublicDataClass:
+    active: true
+    excludes: ['**']
+    ignorePackages:
+      - '*.internal'
+      - '*.internal.*'
+  ForbiddenVoid:
+    active: false
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  FunctionOnlyReturningConstant:
+    active: true
+    ignoreOverridableFunction: true
+    ignoreActualFunction: true
+    excludedFunctions: ''
+  LibraryCodeMustSpecifyReturnType:
+    active: true
+    excludes: ['**']
+  LibraryEntitiesShouldNotBePublic:
+    active: true
+    excludes: ['**']
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    ignoreNumbers:
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+    ignoreRanges: false
+    ignoreExtensionFunctions: true
+  MandatoryBracesIfStatements:
+    active: false
+  MandatoryBracesLoops:
+    active: false
+  MaxLineLength:
+    active: false
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: true
+  MultilineLambdaItParameter:
+    active: false
+  NestedClassesVisibility:
+    active: true
+  NewLineAtEndOfFile:
+    active: true
+  NoTabs:
+    active: false
+  ObjectLiteralToLambda:
+    active: false
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  OptionalWhenBraces:
+    active: false
+  PreferToOverPairSyntax:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: false
+  RedundantHigherOrderMapUsage:
+    active: false
+  RedundantVisibilityModifierRule:
+    active: false
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions: 'equals'
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: true
+  SpacingBetweenPackageAndImports:
+    active: false
+  ThrowsCount:
+    active: true
+    max: 2
+    excludeGuardClauses: false
+  TrailingWhitespace:
+    active: false
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableLength: 4
+    allowNonStandardGrouping: false
+  UnnecessaryAbstractClass:
+    active: true
+  UnnecessaryAnnotationUseSiteTarget:
+    active: false
+  UnnecessaryApply:
+    active: true
+  UnnecessaryFilter:
+    active: false
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryInnerClass:
+    active: false
+  UnnecessaryLet:
+    active: false
+  UnnecessaryParentheses:
+    active: false
+  UntilInsteadOfRangeTo:
+    active: false
+  UnusedImports:
+    active: false
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    allowedNames: '(_|ignored|expected|serialVersionUID)'
+  UseAnyOrNoneInsteadOfFind:
+    active: false
+  UseArrayLiteralsInAnnotations:
+    active: false
+  UseCheckNotNull:
+    active: false
+  UseCheckOrError:
+    active: false
+  UseDataClass:
+    active: false
+    allowVars: false
+  UseEmptyCounterpart:
+    active: false
+  UseIfEmptyOrIfBlank:
+    active: false
+  UseIfInsteadOfWhen:
+    active: false
+  UseIsNullOrEmpty:
+    active: false
+  UseOrEmpty:
+    active: false
+  UseRequire:
+    active: false
+  UseRequireNotNull:
+    active: false
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+  WildcardImport:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludeImports:
+      - 'java.util.*'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Applies same missing annotation field logic as return type for an `@Body` parameter in a Retrofit request
- Adds and configures Detekt for static analysis (with baseline for current warning)
- Minor version upgrades for Kotlin, Gradle, and Lint
- Some minor formatting changes for Detekt