### PR TITLE
Check for body missing @JsonObject annotation.

### DIFF
--- a/checks/src/main/java/com/kozaxinan/android/checks/IssueRegistry.kt
+++ b/checks/src/main/java/com/kozaxinan/android/checks/IssueRegistry.kt
@@ -6,11 +6,11 @@ import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.kozaxinan.android.checks.ImmutableDataClassDetector.Companion.ISSUE_IMMUTABLE_DATA_CLASS_RULE
 import com.kozaxinan.android.checks.NetworkLayerClassImmutabilityDetector.Companion.ISSUE_NETWORK_LAYER_IMMUTABLE_CLASS_RULE
+import com.kozaxinan.android.checks.NetworkLayerClassJsonDetector.Companion.ISSUE_NETWORK_LAYER_CLASS_JSON_CLASS_BODY_RULE
 import com.kozaxinan.android.checks.NetworkLayerClassJsonDetector.Companion.ISSUE_NETWORK_LAYER_CLASS_JSON_CLASS_RULE
 import com.kozaxinan.android.checks.NetworkLayerClassJsonDetector.Companion.ISSUE_NETWORK_LAYER_CLASS_JSON_RULE
 import com.kozaxinan.android.checks.NetworkLayerClassSerializedNameDetector.Companion.ISSUE_NETWORK_LAYER_CLASS_SERIALIZED_NAME_RULE
 
-@Suppress("UnstableApiUsage")
 internal class IssueRegistry : IssueRegistry() {
 
     override val issues: List<Issue> = listOf(
@@ -18,7 +18,8 @@ internal class IssueRegistry : IssueRegistry() {
         ISSUE_NETWORK_LAYER_CLASS_SERIALIZED_NAME_RULE,
         ISSUE_NETWORK_LAYER_IMMUTABLE_CLASS_RULE,
         ISSUE_NETWORK_LAYER_CLASS_JSON_RULE,
-        ISSUE_NETWORK_LAYER_CLASS_JSON_CLASS_RULE
+        ISSUE_NETWORK_LAYER_CLASS_JSON_CLASS_RULE,
+        ISSUE_NETWORK_LAYER_CLASS_JSON_CLASS_BODY_RULE,
     )
 
     override val api: Int = CURRENT_API


### PR DESCRIPTION
Not sure if it'd be better to do a separate detector for this? Also @Body are not checking for @Json annotations - which is a difference from the rest of the checks. Maybe that check should be added?

I still felt that adding this is a step towards better coverage for the lint checks - even if not checking for @Json annotations currently. 